### PR TITLE
Fixes for building on python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ otp_client_py
 Python client for OTP
 
 Install and run example app:
-  0. install python 2.7, along with zc.buildout and easy_install, git
-  1. git clone https://github.com/OpenTransitTools/otp_client_py.git
-  2. cd otp_client_py
-  3. buildout
-  4. bin/trip_planner "from=pdx&to=zoo" trimet p
+  1. install python 3.x, along with zc.buildout and git
+  2. git clone https://github.com/OpenTransitTools/otp_client_py.git
+  3. cd otp_client_py
+  4. buildout 
+  5. buildout (workaround for issue during build) 
+  6. bin/trip_planner "from=pdx&to=zoo" trimet p
 
 This code has been tested to run TriMet's instance of OTP and SOLR geocoder.  To get another OTP instance and/or SOLR geocoder up and running, see opentripplanner.org (v *.10.x) and geocoder project.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-import sys
+
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -10,7 +10,7 @@ requires = [
     # 6/4/2020: 3 pins needed to make this build 
     'requests==2.21.0',
     'decorator<5.0',
-    'SQLAlchemy<1.4',
+    'SQLAlchemy>=1.4',
 
     'ott.utils',
     'ott.geocoder',
@@ -25,7 +25,7 @@ requires = [
     'waitress==1.4.3',
 
     'venusian==1.2.0',
-    'protobuf<3.0' # 3.x requires 'six>=1.9' ... but some other lib wants six=1.4
+    'protobuf<3.0'  # 3.x requires 'six>=1.9' ... but some other lib wants six=1.4
 ]
 
 extras_require = dict(


### PR DESCRIPTION
Hi there,

I just gave this repository a try and found some issues, when executing the Readme.md instructions on a recent Python 3.10 Interpreter. This PR includes the necessary fixes to make the instructions work.

I plan to work on a otp python client and wanted to check the current status of this one. Are you aware of a recent python client for otp (v2) and would you be happy when I contribute to this one? I would prefer to contribute to an existing one, instead of creating a new one.

Best regards

Max